### PR TITLE
Refactor views around building tree view

### DIFF
--- a/lib/mantra/contents.ex
+++ b/lib/mantra/contents.ex
@@ -28,7 +28,10 @@ defmodule Mantra.Contents do
         block_changeset =
           Block.create_changeset(
             %Block{},
-            Map.put(block_params, :ancestors, [page.id])
+            Map.merge(block_params, %{
+              ancestors: [page.id],
+              positions: [block_params[:position] | [page.id]]
+            })
           )
 
         contents_repo().add_block_to_page(page, block_changeset)
@@ -44,7 +47,10 @@ defmodule Mantra.Contents do
         block_changeset =
           Block.create_changeset(
             %Block{},
-            Map.put(block_params, :ancestors, [parent_block.id | parent_block.ancestors])
+            Map.merge(block_params, %{
+              ancestors: [parent_block.id | parent_block.ancestors],
+              positions: [block_params[:position] | parent_block.positions]
+            })
           )
 
         contents_repo().add_block_to_block(parent_block, block_changeset)

--- a/lib/mantra/contents/block.ex
+++ b/lib/mantra/contents/block.ex
@@ -10,6 +10,7 @@ defmodule Mantra.Contents.Block do
           ancestors: [String.t()],
           links: [Link.t()],
           position: String.t(),
+          positions: [String.t(), ...],
           todo: Todo.t() | nil
         }
 
@@ -19,13 +20,14 @@ defmodule Mantra.Contents.Block do
     field :ancestors, {:array, :string}
     field :links, {:array, :string}
     field :position, :string
+    field :positions, {:array, :string}
     embeds_one :todo, Todo, on_replace: :update
   end
 
   def create_changeset(block, params \\ %{}) do
     block
-    |> cast(params, [:content, :ancestors, :position])
-    |> validate_required([:content, :ancestors, :position])
+    |> cast(params, [:content, :ancestors, :position, :positions])
+    |> validate_required([:content, :ancestors, :position, :positions])
     |> put_links()
     |> cast_embed(:todo)
   end

--- a/priv/couch/blocks/blocks/views/page-blocks/map.js
+++ b/priv/couch/blocks/blocks/views/page-blocks/map.js
@@ -1,6 +1,5 @@
 function (doc) {
   if (doc.document_type == "block") {
-    const page_id = doc.ancestors[doc.ancestors.length -1]
-    emit([page_id, doc.ancestors.length, doc.position])
+    emit(doc.positions.slice().reverse().join(''))
   }
 }


### PR DESCRIPTION
The old page blocks view would return a breadth first view of the note tree. In practice this was not going to work since nested blocks need to be seen before siblings to a parent block. By adding a new positions ancestry chain its possible to put the blocks into an order that will be more proper for the UI to render.

There could be an issue in the key getting way too long if the positions are allowed to get too long. This will get fixed when the logic that handles reordering blocks makes sure their position stays within a reasonable range.